### PR TITLE
Use preinstalled Java installation in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,15 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        distribution: temurin
-        java-version: 17
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Temurin is preinstalled on GitHub's Ubuntu image, so specifying a custom image is not necessary.